### PR TITLE
[Version fix] - Decanter and copyright year

### DIFF
--- a/src/main/webapp/archives.html
+++ b/src/main/webapp/archives.html
@@ -724,7 +724,7 @@
             <div class="row-fluid">
                 <div class="span12">
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>

--- a/src/main/webapp/cave_installation.html
+++ b/src/main/webapp/cave_installation.html
@@ -87,7 +87,7 @@
             <div class="row-fluid">
                 <div class="span12">
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>

--- a/src/main/webapp/cellar_installation.html
+++ b/src/main/webapp/cellar_installation.html
@@ -88,7 +88,7 @@
             <div class="row-fluid">
                 <div class="span12">
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>

--- a/src/main/webapp/community.html
+++ b/src/main/webapp/community.html
@@ -390,7 +390,7 @@
             <div class="row-fluid">
                 <div class="span12">
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>

--- a/src/main/webapp/decanter_installation.html
+++ b/src/main/webapp/decanter_installation.html
@@ -78,7 +78,7 @@
             <div class="row-fluid">
                 <div class="span12">
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>

--- a/src/main/webapp/documentation.html
+++ b/src/main/webapp/documentation.html
@@ -207,7 +207,7 @@
             <div class="row-fluid">
                 <div class="span12">
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>

--- a/src/main/webapp/download.html
+++ b/src/main/webapp/download.html
@@ -653,7 +653,7 @@
             <div class="row-fluid">
                 <div class="span12">
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -366,7 +366,7 @@
                     <div class="footer-documentation--title">Ready, efficient, and productive with Karaf in a minute !</div>
                     <div class="footer-documentation--link"><a class="btn btn-large btn-success" href="documentation.html">Read Documentation</a></div>
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -77,7 +77,7 @@
                         <center>
                             <div class="banner--text">
                                <div class="container-fluid">
-                                <b>Karaf Decanter 2.2.0 has been released! (6/1/18)</b> - This is a new Decanter series, providing new features and bug fixes. It's designed to work specifically on Apache Karaf 4.x.  (<a class="banner--link" href="javascript:var w = window.open('https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12341053')">Release Notes</a>)
+                                <b>Karaf Decanter 2.0.0 has been released! (6/2/18)</b> - This is a new Decanter series, providing new features and bug fixes. It's designed to work specifically on Apache Karaf 4.x.  (<a class="banner--link" href="javascript:var w = window.open('https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12341053')">Release Notes</a>)
                                </div>
                            </div>
                         </center>
@@ -324,7 +324,7 @@
                                     Monitoring, alerting, and BAM with <br><br>
                                     <a href="projects.html#decanter">Karaf Decanter</a>
                                     <div class="offset4 offset-feature--separator"></div>
-                                    Last version <a href="download.html">1.4.0</a><br>(23/07/17)<br>
+                                    Last version <a href="download.html">2.0.0</a><br>(06/02/18)<br>
                                 </div>
                             </div>
                         </div>

--- a/src/main/webapp/news.html
+++ b/src/main/webapp/news.html
@@ -718,7 +718,7 @@
             <div class="row-fluid">
                 <div class="span12">
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>

--- a/src/main/webapp/privacy.html
+++ b/src/main/webapp/privacy.html
@@ -72,7 +72,7 @@
             <div class="row-fluid">
                 <div class="span12">
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>

--- a/src/main/webapp/projects.html
+++ b/src/main/webapp/projects.html
@@ -328,7 +328,7 @@
             <div class="row-fluid">
                 <div class="span12">
                     <div class="footer-documentation--text">
-                    &copy; <span>2017</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
+                    &copy; <span>2018</span> <a href="http://www.apache.org">Apache Software Foundation</a> - <a
                         href="privacy.html">Privacy Policy</a><br/>
                     Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are
                     trademarks of The Apache Software Foundation.</div>


### PR DESCRIPTION
This pull request fix version of Decanter on the main page :

- in the news slideshow
- in the latest release block

This also upgrade the copyright year