### PR TITLE
Update links for examples to existing URLs

### DIFF
--- a/src/main/webapp/documentation.html
+++ b/src/main/webapp/documentation.html
@@ -162,126 +162,126 @@
                     <tr>
                         <td><strong>Blueprint</strong></td>
                         <td>using services with XML or annotations.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-blueprint-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-blueprint-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Branding</strong></td>
                         <td>branding the look'n feel of the shell console for your own Karaf distribution.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-branding-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-branding-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Shell Command</strong></td>
                         <td>creating a shell command.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-command-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-command-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Deployer</strong></td>
                         <td>creating a Karaf deployer service on the deploy folder.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-deployer-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-deployer-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Dump</strong></td>
                         <td>creating a dump provider service.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-dump-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-dump-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Integration test</strong></td>
                         <td>creating integration tests in addition of unit tests for your bundles.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-itest-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-itest-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>JDBC</strong></td>
                         <td>using simple JDBC implementation with Pax-JDBC and an Apache Derby embedded database.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-jdbc-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-jdbc-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>JPA</strong></td>
                         <td>using JPA with entity manager for the persistence implementation.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-jpa-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-jpa-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Pax Logging Appender</strong></td>
                         <td>registering a custom Pax Logging appender.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-log-appender-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-log-appender-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Maven</strong></td>
                         <td>using the Karaf Maven plugin with goals like assembly, client, deploy, kar, run...</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-maven-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-maven-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>MBean</strong></td>
                         <td>registering a JMX MBean in the Apache Karaf MBeanServer</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-mbean-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-mbean-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Profile</strong></td>
                         <td>creating several profiles (in a registry) and use these profiles to create custom distributions.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-profile-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-profile-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>REST</strong></td>
                         <td>using JAX-RS to implement a REST service.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-rest-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-rest-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Scheduler</strong></td>
                         <td>creating a runnable service periodically executed by the Apache Karaf scheduler.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-scheduler-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-scheduler-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Service Component Runtime</strong></td>
                         <td>using services with annotations with the OSGi compendium specification.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-scr-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-scr-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>Servlet</strong></td>
                         <td>registering a servlet in the Karaf HTTP Service with different approaches.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-servlet-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-servlet-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>SOAP</strong></td>
                         <td>using JAX-WS to implement a SOAP service.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-soap-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-soap-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>
                     <tr>
                         <td><strong>URL Namespace Handler</strong></td>
                         <td>creating a new URL namespace handler and use it in all Apache Karaf parts.</td>
-                        <td><a href="https://github.com/jbonofre/karaf/tree/DEV_GUIDE/examples/karaf-url-namespace-handler-example" target="_blank">
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-url-namespace-handler-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>


### PR DESCRIPTION
The links for examples link to non-existent pages (404-error).

They point to a non-existent branch on a fork of the github karaf repository. Updated the links to point to the master branch of the main karaf repo on github.