### PR TITLE
Add Karaf Cellar releases 4.0.5 and 4.1.2

### DIFF
--- a/src/main/webapp/archives.html
+++ b/src/main/webapp/archives.html
@@ -558,12 +558,20 @@
                     </thead>
                     <tbody>
                         <tr>
-                        <td>4.1.0</td>
-                        <td><a href="javascript:var w = window.open('download.html')">Installation Instructions</a></td>
-                        <td><a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.tar.gz">tar.gz</a> [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.tar.gz.asc">PGP</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.tar.gz.md5">MD5</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.tar.gz.sha1">SHA1</a>]<br>
-                                    <a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.zip">zip</a> [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.zip.asc">PGP</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.zip.md5">MD5</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.zip.sha1">SHA1</a>]
-                        </td>
-                        <td><a href="javascript:var w = window.open('https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12340615')">Release Notes</a></td>
+                            <td>4.1.1</td>
+                            <td><a href="javascript:var w = window.open('download.html')">Installation Instructions</a></td>
+                            <td><a href="http://archive.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.tar.gz">tar.gz</a> [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.tar.gz.asc">PGP</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.tar.gz.md5">MD5</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.tar.gz.sha1">SHA1</a>]<br>
+                                        <a href="http://archive.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.zip">zip</a> [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.zip.asc">PGP</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.zip.md5">MD5</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.zip.sha1">SHA1</a>]
+                            </td>
+                            <td><a href="javascript:var w = window.open('https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12340615')">Release Notes</a></td>
+                        </tr>
+                        <tr>
+                            <td>4.1.0</td>
+                            <td><a href="javascript:var w = window.open('download.html')">Installation Instructions</a></td>
+                            <td><a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.tar.gz">tar.gz</a> [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.tar.gz.asc">PGP</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.tar.gz.md5">MD5</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.tar.gz.sha1">SHA1</a>]<br>
+                                        <a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.zip">zip</a> [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.zip.asc">PGP</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.zip.md5">MD5</a>] [<a href="http://archive.apache.org/dist/karaf/cellar/4.1.0/apache-karaf-cellar-4.1.0-src.zip.sha1">SHA1</a>]
+                            </td>
+                            <td><a href="javascript:var w = window.open('https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12340615')">Release Notes</a></td>
                         </tr>
 
                         <tr>

--- a/src/main/webapp/download.html
+++ b/src/main/webapp/download.html
@@ -87,16 +87,16 @@
           <div class="card flex-md-row mb-4 box-shadow h-md-250">
             <div class="card-body d-flex flex-column align-items-start">
               <strong class="d-inline-block mb-2 text-success"><i class="fas fa-circle"></i> Latest release</strong>
-              <h3 class="mb-0 text-dark">Karaf Cellar <span class="text-muted">4.1.1</span></h3>
-              <div class="mb-1 text-muted">October 16, 2017</div>
+              <h3 class="mb-0 text-dark">Karaf Cellar <span class="text-muted">4.1.2</span></h3>
+              <div class="mb-1 text-muted">October 12, 2018</div>
               <p class="card-text mb-auto">
                 Installation Instructions:
                   <a href="#cellar-installation">installation</a>
               </p>
               <p class="card-text mb-auto">
                 Source Distribution :
-                  <a href="http://www.apache.org/dyn/closer.lua/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.tar.gz">tar.gz</a> [<a href="https://www.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.tar.gz.asc">PGP</a>] [<a href="https://www.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.tar.gz.sha1">SHA1</a>] - 
-                                <a href="http://www.apache.org/dyn/closer.lua/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.zip">zip</a> [<a href="https://www.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.zip.asc">PGP</a>] [<a href="https://www.apache.org/dist/karaf/cellar/4.1.1/apache-karaf-cellar-4.1.1-src.zip.sha1">SHA1</a>]
+                  <a href="http://www.apache.org/dyn/closer.lua/karaf/cellar/4.1.2/apache-karaf-cellar-4.1.2-src.tar.gz">tar.gz</a> [<a href="https://www.apache.org/dist/karaf/cellar/4.1.2/apache-karaf-cellar-4.1.2-src.tar.gz.asc">PGP</a>] [<a href="https://www.apache.org/dist/karaf/cellar/4.1.2/apache-karaf-cellar-4.1.2-src.tar.gz.sha512">SHA512</a>] - 
+                                <a href="http://www.apache.org/dyn/closer.lua/karaf/cellar/4.1.2/apache-karaf-cellar-4.1.2-src.zip">zip</a> [<a href="https://www.apache.org/dist/karaf/cellar/4.1.2/apache-karaf-cellar-4.1.2-src.zip.asc">PGP</a>] [<a href="https://www.apache.org/dist/karaf/cellar/4.1.2/apache-karaf-cellar-4.1.2-src.zip.sha512">SHA512</a>]
               </p>
               <a class="btn btn-outline-dark mt-3" href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12340615" role="button" target="_blank">Release note &raquo;</a>
             </div>
@@ -337,17 +337,17 @@
                       <td>4.1.x</td>
                       <td>4.1.x / 4.2.x</td>
                       <td class="text-success">Stable</td>
-                      <td>4.1.1</td>
                       <td>4.1.2</td>
-                      <td>5 Oct 2018</td>
+                      <td>4.1.3</td>
+                      <td>12 Jan 2019</td>
                     </tr>
                     <tr>
                         <td>4.0.x</td>
                         <td>4.0.x</td>
                         <td class="text-success">Stable</td>
-                        <td>4.0.4</td>
                         <td>4.0.5</td>
-                        <td>5 Oct 2018</td>
+                        <td>4.0.6</td>
+                        <td>12 Jan 2019</td>
                     </tr>
                     <tr>
                         <td>3.0.x</td>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -84,6 +84,20 @@
           <div class="carousel-item active">
             <div class="container">
               <div class="carousel-caption">
+                <p><strong>Karaf Cellar 4.1.2 has been released! (12/10/18)</strong> - This is an update patch for Apache Cellar 4.1.x, containing bug fixes and improvements. (<a href="news.html">Details</a>)</p>
+              </div>
+            </div>
+          </div>
+          <div class="carousel-item">
+            <div class="container">
+              <div class="carousel-caption">
+                <p><strong>Karaf Cellar 4.0.5 has been released! (12/10/18)</strong> - This is an update patch for Apache Cellar 4.0.x, containing bug fixes and improvements. (<a href="news.html">Details</a>)</p>
+              </div>
+            </div>
+          </div>
+          <div class="carousel-item">
+            <div class="container">
+              <div class="carousel-caption">
                 <p><strong>Karaf Decanter 2.1.0 has been released! (12/9/18)</strong> - This is an update patch for Apache Decanter 2.x.x, containing bug fixes and improvements. (<a href="news.html">Details</a>)</p>
               </div>
             </div>
@@ -106,20 +120,6 @@
             <div class="container">
               <div class="carousel-caption">
                 <p><strong>Karaf Runtime 4.1.6 has been released! (6/8/18)</strong> - This is an update patch for Apache Karaf 4.1.x, containing bug fixes and improvements. (<a href="news.html">Details</a>)</p>
-              </div>
-            </div>
-          </div>
-          <div class="carousel-item">
-            <div class="container">
-              <div class="carousel-caption">
-                <p><strong>Karaf Runtime 4.2.0 has been released ! (9/4/18)</strong> - This is the first GA release on the 4.2.x series. We invite users to upgrade to this new stable series, bringing a lot of fixes, improvements and new features. (<a href="news.html">Details</a>)</p>
-              </div>
-            </div>
-          </div>
-          <div class="carousel-item">
-            <div class="container">
-              <div class="carousel-caption">
-                <p><strong>Karaf Runtime 3.0.9 has been released! (2/3/18)</strong> - This is an update patch for Apache Karaf 3.0.x, containing minor fixes and dependency upgrades. (<a href="news.html">Details</a>)</p>
               </div>
             </div>
           </div>
@@ -218,7 +218,7 @@
           <div class="col-md-7 order-md-2">
             <h2 class="featurette-heading">Manage bunch of clustered instances with <span class="text-muted">Karaf Cellar.</span></h2>
             <p class="lead">You have bunch of Karaf Runtime instances running ? You want to manage those instances as one, spreading the configuration, deployment, etc ? Karaf Cellar is for you. Karaf Cellar is a clustering solution for Karaf. It allows you to manage multiple instances, with synchronization between the instances.</p>
-            <p>Last version <strong>4.1.0</strong> - (14/10/17)</p>
+            <p>Last version <strong>4.1.2</strong> - (12/10/18)</p>
             <p><a class="btn btn-primary" href="projects.html" role="button">Learn more &raquo;</a></p>
           </div>
           <div class="col-md-5 order-md-1">

--- a/src/main/webapp/news.html
+++ b/src/main/webapp/news.html
@@ -103,18 +103,29 @@
               <h2 class="pb-3 mb-4 font-italic border-bottom"><i class="fas fa-bullhorn"></i> Fresh news</h2>
 
               <div class="pb-4 mb-3">
-                <h3 class="text-dark">Karaf Decanter 2.1.0 has been released ! <span class="text-muted">September 12, 2018</span></h3>
-                <p>This is a major maintenance release on Decanter 2.x series. Especially, it provides:</p>
+                <h3 class="text-dark">Karaf Cellar 4.1.2 has been released ! <span class="text-muted">October 12, 2018</span></h3>
+                <p>This is a major maintenance release on Cellar 4.1.x series. Especially, it provides:</p>
                 <ul>
-                  <li>New JDBC collector</li>
-                  <li>Fix and improvements on the JMS collector and appender</li>
-                  <li>Upgrade Kafka collector and appender to support Kafka 1.x</li>
-                  <li>Improvements on the JMX collector to be able to execute MBean operations</li>
-                  <li>Add new raw and parser services</li>
+                  <li>Improve cellar groups configuration synchronisation from hazelcast</li>
+                  <li>Upgrade Hazelcast to 3.9.1</li>
+                  <li>Upgrade Kubernetes-client to 3.1.0</li>
                 </ul>
                 <p>and much more !</p>
                 <a class="btn btn-outline-primary" href="download.html">Download &raquo;</a>
-                <a class="btn btn-outline-primary" href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12342684" target="_blank">Release Notes &raquo;</a>
+                <a class="btn btn-outline-primary" href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12341724" target="_blank">Release Notes &raquo;</a>
+              </div><!-- /.blog-post -->
+
+              <div class="pb-4 mb-3">
+                <h3 class="text-dark">Karaf Cellar 4.0.5 has been released ! <span class="text-muted">October 12, 2018</span></h3>
+                <p>This is a major maintenance release on Cellar 4.0.x series. Especially, it provides:</p>
+                <ul>
+                  <li>Improve cellar groups configuration synchronisation from hazelcast</li>
+                  <li>Upgrade Hazelcast to 3.9.1</li>
+                  <li>Upgrade Kubernetes-client to 3.1.0</li>
+                </ul>
+                <p>and much more !</p>
+                <a class="btn btn-outline-primary" href="download.html">Download &raquo;</a>
+                <a class="btn btn-outline-primary" href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12340649" target="_blank">Release Notes &raquo;</a>
               </div><!-- /.blog-post -->
 
               <div class="pb-4 mb-3">

--- a/src/main/webapp/projects.html
+++ b/src/main/webapp/projects.html
@@ -94,7 +94,7 @@
               </h3>
               <p class="card-text mb-auto">Karaf Cellar is a clustering solution for Karaf.</p>
               <p>
-                <small class="text-muted">Latest 4.1.1 <a href="download.html"><i class="fas fa-download"></i></a></small>
+                <small class="text-muted">Latest 4.1.2 <a href="download.html"><i class="fas fa-download"></i></a></small>
               </p>
             </div>
           </div>


### PR DESCRIPTION
@jbonofre I pushed a single PR for the both releases and may be we can update the Cellar series in the download pages by adding Cellar 4.2.x futur series and mark Cellar 4.0.x series as maintenance.

Thoughts ?