### PR TITLE
Fix Whimsy missing requirement links

### DIFF
--- a/src/main/webapp/archives.html
+++ b/src/main/webapp/archives.html
@@ -855,7 +855,13 @@
         <p class="pt-2"><a class="btn btn-primary" href="documentation.html" role="button">Read Documentation &raquo;</a></p>
       </div>
       <p class="float-right"><a href="#">Back to top</a></p>
-      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - <a href="privacy.html">Privacy Policy</a><br/>
+      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - 
+        <a href="privacy.html">Privacy Policy</a> - 
+        <a target="_blank" href="https://www.apache.org/events/current-event.html" title="Apache Events">Apache Events</a> - 
+        <a target="_blank" href="https://www.apache.org/licenses/" title="Licenses">Licenses</a> - 
+        <a target="_blank" href="https://www.apache.org/security/" title="Security">Security</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/sponsorship.html" title="Sponsorship">Sponsorship</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/thanks.html" title="Thanks">Thanks</a><br/>
       Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are trademarks of The Apache Software Foundation.</p>
     </footer>
 

--- a/src/main/webapp/community.html
+++ b/src/main/webapp/community.html
@@ -491,7 +491,13 @@
         <p class="pt-2"><a class="btn btn-primary" href="documentation.html" role="button">Read Documentation &raquo;</a></p>
       </div>
       <p class="float-right"><a href="#">Back to top</a></p>
-      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - <a href="privacy.html">Privacy Policy</a><br/>
+      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - 
+        <a href="privacy.html">Privacy Policy</a> - 
+        <a target="_blank" href="https://www.apache.org/events/current-event.html" title="Apache Events">Apache Events</a> - 
+        <a target="_blank" href="https://www.apache.org/licenses/" title="Licenses">Licenses</a> - 
+        <a target="_blank" href="https://www.apache.org/security/" title="Security">Security</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/sponsorship.html" title="Sponsorship">Sponsorship</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/thanks.html" title="Thanks">Thanks</a><br/>
       Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are trademarks of The Apache Software Foundation.</p>
     </footer>
 

--- a/src/main/webapp/documentation.html
+++ b/src/main/webapp/documentation.html
@@ -533,7 +533,13 @@
         <p class="pt-2"><a class="btn btn-primary" href="documentation.html" role="button">Read Documentation &raquo;</a></p>
       </div>
       <p class="float-right"><a href="#">Back to top</a></p>
-      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - <a href="privacy.html">Privacy Policy</a><br/>
+      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - 
+        <a href="privacy.html">Privacy Policy</a> - 
+        <a target="_blank" href="https://www.apache.org/events/current-event.html" title="Apache Events">Apache Events</a> - 
+        <a target="_blank" href="https://www.apache.org/licenses/" title="Licenses">Licenses</a> - 
+        <a target="_blank" href="https://www.apache.org/security/" title="Security">Security</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/sponsorship.html" title="Sponsorship">Sponsorship</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/thanks.html" title="Thanks">Thanks</a><br/>
       Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are trademarks of The Apache Software Foundation.</p>
     </footer>
 

--- a/src/main/webapp/download.html
+++ b/src/main/webapp/download.html
@@ -584,7 +584,13 @@
         <p class="pt-2"><a class="btn btn-primary" href="documentation.html" role="button">Read Documentation &raquo;</a></p>
       </div>
       <p class="float-right"><a href="#">Back to top</a></p>
-      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - <a href="privacy.html">Privacy Policy</a><br/>
+      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - 
+        <a href="privacy.html">Privacy Policy</a> - 
+        <a target="_blank" href="https://www.apache.org/events/current-event.html" title="Apache Events">Apache Events</a> - 
+        <a target="_blank" href="https://www.apache.org/licenses/" title="Licenses">Licenses</a> - 
+        <a target="_blank" href="https://www.apache.org/security/" title="Security">Security</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/sponsorship.html" title="Sponsorship">Sponsorship</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/thanks.html" title="Thanks">Thanks</a><br/>
       Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are trademarks of The Apache Software Foundation.</p>
     </footer>
 

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -326,7 +326,13 @@
         <p class="pt-2"><a class="btn btn-primary" href="documentation.html" role="button">Read Documentation &raquo;</a></p>
       </div>
       <p class="float-right"><a href="#">Back to top</a></p>
-      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - <a href="privacy.html">Privacy Policy</a><br/>
+      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - 
+        <a href="privacy.html">Privacy Policy</a> - 
+        <a target="_blank" href="https://www.apache.org/events/current-event.html" title="Apache Events">Apache Events</a> - 
+        <a target="_blank" href="https://www.apache.org/licenses/" title="Licenses">Licenses</a> - 
+        <a target="_blank" href="https://www.apache.org/security/" title="Security">Security</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/sponsorship.html" title="Sponsorship">Sponsorship</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/thanks.html" title="Thanks">Thanks</a><br/>
       Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are trademarks of The Apache Software Foundation.</p>
     </footer>
 

--- a/src/main/webapp/news.html
+++ b/src/main/webapp/news.html
@@ -1205,7 +1205,13 @@
         <p class="pt-2"><a class="btn btn-primary" href="documentation.html" role="button">Read Documentation &raquo;</a></p>
       </div>
       <p class="float-right"><a href="#">Back to top</a></p>
-      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - <a href="privacy.html">Privacy Policy</a><br/>
+      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - 
+        <a href="privacy.html">Privacy Policy</a> - 
+        <a target="_blank" href="https://www.apache.org/events/current-event.html" title="Apache Events">Apache Events</a> - 
+        <a target="_blank" href="https://www.apache.org/licenses/" title="Licenses">Licenses</a> - 
+        <a target="_blank" href="https://www.apache.org/security/" title="Security">Security</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/sponsorship.html" title="Sponsorship">Sponsorship</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/thanks.html" title="Thanks">Thanks</a><br/>
       Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are trademarks of The Apache Software Foundation.</p>
     </footer>
 

--- a/src/main/webapp/privacy.html
+++ b/src/main/webapp/privacy.html
@@ -98,7 +98,13 @@
         <p class="pt-2"><a class="btn btn-primary" href="documentation.html" role="button">Read Documentation &raquo;</a></p>
       </div>
       <p class="float-right"><a href="#">Back to top</a></p>
-      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - <a href="privacy.html">Privacy Policy</a><br/>
+      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - 
+        <a href="privacy.html">Privacy Policy</a> - 
+        <a target="_blank" href="https://www.apache.org/events/current-event.html" title="Apache Events">Apache Events</a> - 
+        <a target="_blank" href="https://www.apache.org/licenses/" title="Licenses">Licenses</a> - 
+        <a target="_blank" href="https://www.apache.org/security/" title="Security">Security</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/sponsorship.html" title="Sponsorship">Sponsorship</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/thanks.html" title="Thanks">Thanks</a><br/>
       Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are trademarks of The Apache Software Foundation.</p>
     </footer>
 

--- a/src/main/webapp/projects.html
+++ b/src/main/webapp/projects.html
@@ -501,7 +501,13 @@
         <p class="pt-2"><a class="btn btn-primary" href="documentation.html" role="button">Read Documentation &raquo;</a></p>
       </div>
       <p class="float-right"><a href="#">Back to top</a></p>
-      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - <a href="privacy.html">Privacy Policy</a><br/>
+      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - 
+        <a href="privacy.html">Privacy Policy</a> - 
+        <a target="_blank" href="https://www.apache.org/events/current-event.html" title="Apache Events">Apache Events</a> - 
+        <a target="_blank" href="https://www.apache.org/licenses/" title="Licenses">Licenses</a> - 
+        <a target="_blank" href="https://www.apache.org/security/" title="Security">Security</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/sponsorship.html" title="Sponsorship">Sponsorship</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/thanks.html" title="Thanks">Thanks</a><br/>
       Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are trademarks of The Apache Software Foundation.</p>
     </footer>
 

--- a/src/main/webapp/stories.html
+++ b/src/main/webapp/stories.html
@@ -184,7 +184,13 @@
         <p class="pt-2"><a class="btn btn-primary" href="documentation.html" role="button">Read Documentation &raquo;</a></p>
       </div>
       <p class="float-right"><a href="#">Back to top</a></p>
-      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - <a href="privacy.html">Privacy Policy</a><br/>
+      <p>&copy; 2018 <a href="https://www.apache.org">Apache Software Foundation</a> - 
+        <a href="privacy.html">Privacy Policy</a> - 
+        <a target="_blank" href="https://www.apache.org/events/current-event.html" title="Apache Events">Apache Events</a> - 
+        <a target="_blank" href="https://www.apache.org/licenses/" title="Licenses">Licenses</a> - 
+        <a target="_blank" href="https://www.apache.org/security/" title="Security">Security</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/sponsorship.html" title="Sponsorship">Sponsorship</a> - 
+        <a target="_blank" href="https://www.apache.org/foundation/thanks.html" title="Thanks">Thanks</a><br/>
       Apache Karaf, Karaf, Apache, the Apache feather logo, and the Apache Karaf project logo are trademarks of The Apache Software Foundation.</p>
     </footer>
 


### PR DESCRIPTION
Add missing requirements link as indicated in the Whimsy report:

[https://whimsy.apache.org/site/project/karaf](https://whimsy.apache.org/site/project/karaf)