### PR TITLE
Add link to JMS and HTTP-resource examples

### DIFF
--- a/src/main/webapp/documentation.html
+++ b/src/main/webapp/documentation.html
@@ -205,6 +205,13 @@
                         </a></td>
                     </tr>
                     <tr>
+                        <td><strong>HTTP resource</strong></td>
+                        <td>creating a very simple bundle that just register an empty resource service.</td>
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-http-resource-example" target="_blank">
+                            <img src="images/github.png" width="24px">
+                        </a></td>
+                    </tr>
+                    <tr>
                         <td><strong>Integration test</strong></td>
                         <td>creating integration tests in addition of unit tests for your bundles.</td>
                         <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-itest-example" target="_blank">
@@ -215,6 +222,13 @@
                         <td><strong>JDBC</strong></td>
                         <td>using simple JDBC implementation with Pax-JDBC and an Apache Derby embedded database.</td>
                         <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-jdbc-example" target="_blank">
+                            <img src="images/github.png" width="24px">
+                        </a></td>
+                    </tr>
+                    <tr>
+                        <td><strong>JMS</strong></td>
+                        <td>using a JMS ConnectionFactory service in code that you can implement to interact with JMS.</td>
+                        <td><a href="https://github.com/apache/karaf/tree/master/examples/karaf-jms-example" target="_blank">
                             <img src="images/github.png" width="24px">
                         </a></td>
                     </tr>


### PR DESCRIPTION
I added 2 new links about the JMS and HTTP resource examples in the documentation.