### PR TITLE
Use HTTPS download links

### DIFF
--- a/download.html
+++ b/download.html
@@ -18,21 +18,21 @@ permalink: /download
               <div class="mb-1 text-muted">January 10, 2023</div>
                 <p class="card-text mb-auto">
                     Binary Distribution :
-                    <a href="http://www.apache.org/dyn/closer.lua/karaf/4.4.3/apache-karaf-4.4.3.tar.gz">tar.gz</a>
+                    <a href="https://www.apache.org/dyn/closer.lua/karaf/4.4.3/apache-karaf-4.4.3.tar.gz">tar.gz</a>
                             [<a href="https://www.apache.org/dist/karaf/4.4.3/apache-karaf-4.4.3.tar.gz.asc">PGP</a>]
                             [<a href="https://www.apache.org/dist/karaf/4.4.3/apache-karaf-4.4.3.tar.gz.sha512">SHA512</a>]
                     -
-                    <a href="http://www.apache.org/dyn/closer.lua/karaf/4.4.3/apache-karaf-4.4.3.zip">zip</a>
+                    <a href="https://www.apache.org/dyn/closer.lua/karaf/4.4.3/apache-karaf-4.4.3.zip">zip</a>
                             [<a href="https://www.apache.org/dist/karaf/4.4.3/apache-karaf-4.4.3.zip.asc">PGP</a>]
                             [<a href="https://www.apache.org/dist/karaf/4.4.3/apache-karaf-4.4.3.zip.sha512">SHA512</a>]
                 </p>
                 <p class="card-text mb-auto">
                     Source Distribution :
-                    <a href="http://www.apache.org/dyn/closer.lua/karaf/4.4.3/apache-karaf-4.4.3-src.tar.gz">tar.gz</a>
+                    <a href="https://www.apache.org/dyn/closer.lua/karaf/4.4.3/apache-karaf-4.4.3-src.tar.gz">tar.gz</a>
                             [<a href="https://www.apache.org/dist/karaf/4.4.3/apache-karaf-4.4.3-src.tar.gz.asc">PGP</a>]
                             [<a href="https://www.apache.org/dist/karaf/4.4.3/apache-karaf-4.4.3-src.tar.gz.sha512">SHA512</a>]
                     -
-                    <a href="http://www.apache.org/dyn/closer.lua/karaf/4.4.3/apache-karaf-4.4.3-src.zip">zip</a>
+                    <a href="https://www.apache.org/dyn/closer.lua/karaf/4.4.3/apache-karaf-4.4.3-src.zip">zip</a>
                             [<a href="https://www.apache.org/dist/karaf/4.4.3/apache-karaf-4.4.3-src.zip.asc">PGP</a>]
                             [<a href="https://www.apache.org/dist/karaf/4.4.3/apache-karaf-4.4.3-src.zip.sha512">SHA512</a>]
                 </p>
@@ -48,21 +48,21 @@ permalink: /download
               <div class="mb-1 text-muted">January 14, 2023</div>
                 <p class="card-text mb-auto">
                     Binary Distribution :
-                    <a href="http://www.apache.org/dyn/closer.lua/karaf/4.3.9/apache-karaf-4.3.9.tar.gz">tar.gz</a>
+                    <a href="https://www.apache.org/dyn/closer.lua/karaf/4.3.9/apache-karaf-4.3.9.tar.gz">tar.gz</a>
                             [<a href="https://www.apache.org/dist/karaf/4.3.9/apache-karaf-4.3.9.tar.gz.asc">PGP</a>]
                             [<a href="https://www.apache.org/dist/karaf/4.3.9/apache-karaf-4.3.9.tar.gz.sha512">SHA512</a>]
                     -
-                    <a href="http://www.apache.org/dyn/closer.lua/karaf/4.3.9/apache-karaf-4.3.9.zip">zip</a>
+                    <a href="https://www.apache.org/dyn/closer.lua/karaf/4.3.9/apache-karaf-4.3.9.zip">zip</a>
                             [<a href="https://www.apache.org/dist/karaf/4.3.9/apache-karaf-4.3.9.zip.asc">PGP</a>]
                             [<a href="https://www.apache.org/dist/karaf/4.3.9/apache-karaf-4.3.9.zip.sha512">SHA512</a>]
                 </p>
                 <p class="card-text mb-auto">
                     Source Distribution :
-                    <a href="http://www.apache.org/dyn/closer.lua/karaf/4.3.9/apache-karaf-4.3.9-src.tar.gz">tar.gz</a>
+                    <a href="https://www.apache.org/dyn/closer.lua/karaf/4.3.9/apache-karaf-4.3.9-src.tar.gz">tar.gz</a>
                             [<a href="https://www.apache.org/dist/karaf/4.3.9/apache-karaf-4.3.9-src.tar.gz.asc">PGP</a>]
                             [<a href="https://www.apache.org/dist/karaf/4.3.9/apache-karaf-4.3.9-src.tar.gz.sha512">SHA512</a>]
                     -
-                    <a href="http://www.apache.org/dyn/closer.lua/karaf/4.3.9/apache-karaf-4.3.9-src.zip">zip</a>
+                    <a href="https://www.apache.org/dyn/closer.lua/karaf/4.3.9/apache-karaf-4.3.9-src.zip">zip</a>
                             [<a href="https://www.apache.org/dist/karaf/4.3.9/apache-karaf-4.3.9-src.zip.asc">PGP</a>]
                             [<a href="https://www.apache.org/dist/karaf/4.3.9/apache-karaf-4.3.9-src.zip.sha512">SHA512</a>]
                 </p>
@@ -84,11 +84,11 @@ permalink: /download
               </p>
               <p class="card-text mb-auto">
                 Source Distribution :
-                  <a href="http://www.apache.org/dyn/closer.lua/karaf/cave/4.2.1/apache-karaf-cave-4.2.1-src.tar.gz">tar.gz</a>
+                  <a href="https://www.apache.org/dyn/closer.lua/karaf/cave/4.2.1/apache-karaf-cave-4.2.1-src.tar.gz">tar.gz</a>
                           [<a href="https://www.apache.org/dist/karaf/cave/4.2.1/apache-karaf-cave-4.2.1-src.tar.gz.asc">PGP</a>]
                           [<a href="https://www.apache.org/dist/karaf/cave/4.2.1/apache-karaf-cave-4.2.1-src.tar.gz.sha512">SHA512</a>]
                   -
-                  <a href="http://www.apache.org/dyn/closer.lua/karaf/cave/4.2.1/apache-karaf-cave-4.2.1-src.zip">zip</a>
+                  <a href="https://www.apache.org/dyn/closer.lua/karaf/cave/4.2.1/apache-karaf-cave-4.2.1-src.zip">zip</a>
                           [<a href="https://www.apache.org/dist/karaf/cave/4.2.1/apache-karaf-cave-4.2.1-src.zip.asc">PGP</a>]
                           [<a href="https://www.apache.org/dist/karaf/cave/4.2.1/apache-karaf-cave-4.2.1-src.zip.sha512">SHA512</a>]
               </p>
@@ -108,11 +108,11 @@ permalink: /download
               </p>
               <p class="card-text mb-auto">
                 Source Distribution :
-                  <a href="http://www.apache.org/dyn/closer.lua/karaf/decanter/2.9.0/apache-karaf-decanter-2.9.0-src.tar.gz">tar.gz</a>
+                  <a href="https://www.apache.org/dyn/closer.lua/karaf/decanter/2.9.0/apache-karaf-decanter-2.9.0-src.tar.gz">tar.gz</a>
                           [<a href="https://www.apache.org/dist/karaf/decanter/2.9.0/apache-karaf-decanter-2.9.0-src.tar.gz.asc">PGP</a>]
                           [<a href="https://www.apache.org/dist/karaf/decanter/2.9.0/apache-karaf-decanter-2.9.0-src.tar.gz.sha512">SHA512</a>]
                   -
-                  <a href="http://www.apache.org/dyn/closer.lua/karaf/decanter/2.9.0/apache-karaf-decanter-2.9.0-src.zip">zip</a>
+                  <a href="https://www.apache.org/dyn/closer.lua/karaf/decanter/2.9.0/apache-karaf-decanter-2.9.0-src.zip">zip</a>
                           [<a href="https://www.apache.org/dist/karaf/decanter/2.9.0/apache-karaf-decanter-2.9.0-src.zip.asc">PGP</a>]
                           [<a href="https://www.apache.org/dist/karaf/decanter/2.9.0/apache-karaf-decanter-2.9.0-src.zip.sha512">SHA512</a>]
               </p>
@@ -132,11 +132,11 @@ permalink: /download
               </p>
               <p class="card-text mb-auto">
                 Source Distribution :
-                  <a href="http://www.apache.org/dyn/closer.lua/karaf/cellar/4.2.1/apache-karaf-cellar-4.2.1-src.tar.gz">tar.gz</a>
+                  <a href="https://www.apache.org/dyn/closer.lua/karaf/cellar/4.2.1/apache-karaf-cellar-4.2.1-src.tar.gz">tar.gz</a>
                           [<a href="https://www.apache.org/dist/karaf/cellar/4.2.1/apache-karaf-cellar-4.2.1-src.tar.gz.asc">PGP</a>]
                           [<a href="https://www.apache.org/dist/karaf/cellar/4.2.1/apache-karaf-cellar-4.2.1-src.tar.gz.sha512">SHA512</a>]
                   -
-                  <a href="http://www.apache.org/dyn/closer.lua/karaf/cellar/4.2.1/apache-karaf-cellar-4.2.1-src.zip">zip</a>
+                  <a href="https://www.apache.org/dyn/closer.lua/karaf/cellar/4.2.1/apache-karaf-cellar-4.2.1-src.zip">zip</a>
                           [<a href="https://www.apache.org/dist/karaf/cellar/4.2.1/apache-karaf-cellar-4.2.1-src.zip.asc">PGP</a>]
                           [<a href="https://www.apache.org/dist/karaf/cellar/4.2.1/apache-karaf-cellar-4.2.1-src.zip.sha512">SHA512</a>]
               </p>
@@ -557,7 +557,7 @@ permalink: /download
               <h2 class="pb-3 mb-4 font-italic border-bottom"><i class="fas fa-barcode"></i> Verify the integrity of the files</h2>
               <p>It is essential that you verify the integrity of the downloaded files using the PGP or MD5 signatures.<br/><br/>
                 The PGP signatures can be verified using PGP or GPG. First download the <a href="https://www.apache.org/dist/karaf/KEYS">KEYS</a> as well
-                as the <code>asc</code> signature file for the relevant file. Make sure you get these files from the <a href="http://www.apache.org/dist/karaf">main distribution directory</a>,
+                as the <code>asc</code> signature file for the relevant file. Make sure you get these files from the <a href="https://www.apache.org/dist/karaf">main distribution directory</a>,
                 rather than from a mirror. Then verify the signatures using, for instance:<br/>
                 <code>
                     % gpg --import KEYS


### PR DESCRIPTION
There is a redirect to HTTPS anyhow.
If the redirect stops working one day a MITM attack could occur causing users to install malware.