### PR TITLE
Fix Deploy header in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This command builds website and start the local Jekyll server on http://localhos
 
 NB: your local Jekyll installation might need additional modules required by Apache Karaf website. Just run `bundle install` to install these modules.
 
-## Deploy
+## Deploy
 
 Build the site for production:
 


### PR DESCRIPTION
The Deploy header is not properly rendered because it uses a [non-breaking space](https://en.wikipedia.org/wiki/Non-breaking_space) instead of a normal space.
