### PR TITLE
Fix homepage featurette image responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@ permalink: /
         <p><a class="btn btn-primary" href="/resources/acna20-apache-karaf-modulith-runtime.pdf" role="button">Download &raquo;</a></p>
       </div>
       <div class="col-md-7 order-md-1">
-        <img src="/images/acna20-apache-karaf-modulith-runtime.png" width="600px"/>
+        <img src="/images/acna20-apache-karaf-modulith-runtime.png" class="img-fluid"/>
       </div>
     </div>
 


### PR DESCRIPTION
## Problem
- The featurette image on the homepage used a fixed width (`width="600px"`).
- This featurette image was not responsive on smaller screens.

## What Changed
- Removed the fixed width and made the image responsive for all screens.

## Screenshots
|Before|After|
|-------|------|
|<img width="402" height="598" alt="Screenshot 2026-02-06 011840" src="https://github.com/user-attachments/assets/acc547e7-af92-4111-a4ac-70d960cad31c" />|<img width="402" height="694" alt="Screenshot 2026-02-06 011851" src="https://github.com/user-attachments/assets/efb9e037-3e26-4e6e-a55e-b6c65c9ff358" />|
|<img width="409" height="612" alt="Screenshot 2026-02-06 011830" src="https://github.com/user-attachments/assets/12d0aea0-d4c8-4267-99ea-55ce33a487be" />|<img width="407" height="757" alt="Screenshot 2026-02-06 011804" src="https://github.com/user-attachments/assets/6617f52c-ca4b-4c8c-8e36-c6b145c9a25a" />|