### PR TITLE
Fixing release date for 4.4.10

### DIFF
--- a/news.html
+++ b/news.html
@@ -50,7 +50,7 @@ permalink: /news
               <h2 class="pb-3 mb-4 font-italic border-bottom"><i class="fas fa-bullhorn"></i> Fresh news</h2>
 
               <div class="pb-4 mb-3 border-bottom">
-                <h3 class="text-dark">Karaf OSGi runtime 4.4.10 has been released! <span class="text-muted">February 15, 2025</span></h3>
+                <h3 class="text-dark">Karaf OSGi runtime 4.4.10 has been released! <span class="text-muted">February 13, 2026</span></h3>
                 <p>Apache Karaf runtime 4.4.10 is a maintenance release, bringing a lot of dependency updates and fixes, especially:
                 <ul>
                   <li>Define the required java version range in karaf maven plugins (to avoid Java version error on Maven goal)</li>


### PR DESCRIPTION
The release date on https://karaf.apache.org/news.html for 4.4.10 is wrong:

<img width="864" height="126" alt="Screenshot 2026-02-26 at 10 51 25" src="https://github.com/user-attachments/assets/1222da3e-dc83-425c-999b-b2e8c4819601" />
