### PR TITLE
fix: Fix privacy link and add Foundation link to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,8 @@
   </div>
   <p class="float-right"><a href="#">Back to top</a></p>
   <p>&copy; 2018-2022 <a href="https://www.apache.org">Apache Software Foundation</a> -
-    <a href="/privacy.html">Privacy Policy</a> -
+    <a href="https://www.apache.org/">Foundation</a> -
+    <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a> -
     <a target="_blank" href="https://www.apache.org/events/current-event.html" title="Apache Events">Apache Events</a> -
     <a target="_blank" href="https://www.apache.org/licenses/" title="Licenses">Licenses</a> -
     <a target="_blank" href="https://www.apache.org/security/" title="Security">Security</a> -


### PR DESCRIPTION
Points privacy link to the canonical ASF privacy policy URL (privacy.apache.org) and adds the missing Foundation link.

Checker: https://whimsy.apache.org/site/